### PR TITLE
change to center instead of justify for better responsiveness 

### DIFF
--- a/w2/KHK/css/style.css
+++ b/w2/KHK/css/style.css
@@ -53,7 +53,7 @@ body {
 #nav li {
   color: #000;
   width: 100%;
-  text-align: justify;
+  text-align: center;
   font-size: 20px;
 }
 #nav li a {


### PR DESCRIPTION
when resizing the window, the issue appears that member's contact information (Full name, studentID, etc) has its structure messed up; I find that changing from 'justify' to 'center' help alleviate this issue, and still looks decent and consistent across the sites. Please check and let me know.
<br>Below is how the information is displayed with 'justify' at 'text-align' property (within style.css) when the window is resized.
![image](https://github.com/user-attachments/assets/41ecf0fe-02b7-4726-a433-20fee246985e)


### PS: Làm kiểu này cho zui, cho quen với workflow của GitHub hoiii, vui vẻ hông quạu nhoa, nói chung đổi sang 'center' cho đỡ? hông thì thôi 'justify' cũng đc, thầy hông yêu cầu responsive gì hết (chắc là "chưa yêu cầu" :)))) )